### PR TITLE
send start and end timestamps as epoch

### DIFF
--- a/lib/chef/handler/opsmatic.rb
+++ b/lib/chef/handler/opsmatic.rb
@@ -34,8 +34,8 @@ class Chef
           :summary => summary,
           :data => {
             :status      => run_status.success? ? "success" : "failure",
-            :start_time  => run_status.start_time,
-            :end_time    => run_status.end_time,
+            :start_time  => run_status.start_time.to_i,
+            :end_time    => run_status.end_time.to_i,
             :duration    => run_status.elapsed_time,
             :updated_resources => []
           }

--- a/lib/chef/handler/version.rb
+++ b/lib/chef/handler/version.rb
@@ -1,7 +1,7 @@
 module Chef
   module Handler
     module Opsmatic
-      VERSION = "0.0.2"
+      VERSION = "0.0.3"
     end
   end
 end


### PR DESCRIPTION
Updates start and end timestamps to return epoch value instead of stringified representation
